### PR TITLE
Fix firebase auth: use getIdToken instead of undocumented variables on user object

### DIFF
--- a/components/Auth/FirebaseAuth.jsx
+++ b/components/Auth/FirebaseAuth.jsx
@@ -10,6 +10,7 @@ import { mapUserData } from '../../utils/auth/mapUserData';
 initFirebase();
 
 const firebaseAuthConfig = {
+  // only 'popup' method works which does not work consistently on mobile https://github.com/vercel/next.js/pull/18599
   signInFlow: 'popup',
   signInOptions: [ // https://github.com/firebase/firebaseui-web#configure-oauth-providers
     firebase.auth.GoogleAuthProvider.PROVIDER_ID,

--- a/components/Auth/FirebaseAuth.jsx
+++ b/components/Auth/FirebaseAuth.jsx
@@ -10,7 +10,7 @@ import { mapUserData } from '../../utils/auth/mapUserData';
 initFirebase();
 
 const firebaseAuthConfig = {
-  signInFlow: 'redirect',
+  signInFlow: 'popup',
   signInOptions: [ // https://github.com/firebase/firebaseui-web#configure-oauth-providers
     firebase.auth.GoogleAuthProvider.PROVIDER_ID,
     firebase.auth.FacebookAuthProvider.PROVIDER_ID,
@@ -36,22 +36,13 @@ const firebaseAuthConfig = {
 //   </Flex>
 // );
 
-const FirebaseAuth = () => {
-  // Do not SSR FirebaseUI, because it is not supported.
-  // https://github.com/firebase/firebaseui-web/issues/213
-  const [renderAuth, setRenderAuth] = useState(false);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setRenderAuth(true);
-    }
-  }, []);
-  if (!renderAuth) return null;
-  return (
+const FirebaseAuth = () => (
+  <div>
     <StyledFirebaseAuth
       uiConfig={firebaseAuthConfig}
       firebaseAuth={firebase.auth()}
     />
-  );
-};
+  </div>
+);
 
 export default FirebaseAuth;

--- a/components/Auth/FirebaseAuth.jsx
+++ b/components/Auth/FirebaseAuth.jsx
@@ -18,21 +18,23 @@ const firebaseAuthConfig = {
   credentialHelper: 'none',
   signInSuccessUrl: '/dashboard',
   callbacks: {
-    // related: https://stackoverflow.com/questions/63349204/signinsuccesswithauthresult-return-value-in-firebase-ui-callbacks
     signInSuccessWithAuthResult: async ({ user }, redirectUrl) => {
+      console.log('sign in successful with auth callback')
       const userData = await mapUserData(user);
       setUserCookie(userData);
+      // related: https://stackoverflow.com/questions/63349204/signinsuccesswithauthresult-return-value-in-firebase-ui-callbacks
       // return false;
     },
   },
 };
 
-const Authenticating = () => (
-  <Flex align="center" justify="center">
-    <Spinner size="24px" mr={2} />
-    <Text>Authenticating...</Text>
-  </Flex>
-);
+// // Not sure how to get this to render inside of StyledFirebaseAuth after user clicks on sign in method
+// const Authenticating = () => (
+//   <Flex align="center" justify="center">
+//     <Spinner size="24px" mr={2} />
+//     <Text>Authenticating...</Text>
+//   </Flex>
+// );
 
 const FirebaseAuth = () => {
   // Do not SSR FirebaseUI, because it is not supported.
@@ -43,15 +45,12 @@ const FirebaseAuth = () => {
       setRenderAuth(true);
     }
   }, []);
+  if (!renderAuth) return null;
   return (
-    <div>
-      {renderAuth ? (
-        <StyledFirebaseAuth
-          uiConfig={firebaseAuthConfig}
-          firebaseAuth={firebase.auth()}
-        />
-      ) : <Authenticating />}
-    </div>
+    <StyledFirebaseAuth
+      uiConfig={firebaseAuthConfig}
+      firebaseAuth={firebase.auth()}
+    />
   );
 };
 

--- a/components/Auth/FirebaseAuth.jsx
+++ b/components/Auth/FirebaseAuth.jsx
@@ -19,10 +19,10 @@ const firebaseAuthConfig = {
   signInSuccessUrl: '/dashboard',
   callbacks: {
     // related: https://stackoverflow.com/questions/63349204/signinsuccesswithauthresult-return-value-in-firebase-ui-callbacks
-    signInSuccessWithAuthResult: ({ user }) => {
-      const userData = mapUserData(user);
+    signInSuccessWithAuthResult: async ({ user }, redirectUrl) => {
+      const userData = await mapUserData(user);
       setUserCookie(userData);
-      return false;
+      // return false;
     },
   },
 };

--- a/utils/auth/mapUserData.js
+++ b/utils/auth/mapUserData.js
@@ -1,6 +1,7 @@
 export const mapUserData = async (user) => {
   const { uid, email } = user;
   const token = await user.getIdToken(true)
+  console.log('got token in mapUserData', token)
   return {
     id: uid,
     email,

--- a/utils/auth/mapUserData.js
+++ b/utils/auth/mapUserData.js
@@ -1,8 +1,9 @@
-export const mapUserData = (user) => {
-  const { uid, email, xa } = user;
+export const mapUserData = async (user) => {
+  const { uid, email } = user;
+  const token = await user.getIdToken(true)
   return {
     id: uid,
     email,
-    token: xa,
+    token,
   };
 };

--- a/utils/auth/useUser.js
+++ b/utils/auth/useUser.js
@@ -34,6 +34,7 @@ const useUser = () => {
     const cancelAuthListener = firebase
       .auth()
       .onIdTokenChanged(async (user) => {
+        console.log('onIdTokenChanged user', user)
         if (user) {
           const userData = await mapUserData(user)
           setUserCookie(userData)

--- a/utils/auth/useUser.js
+++ b/utils/auth/useUser.js
@@ -31,17 +31,23 @@ const useUser = () => {
     // Firebase updates the id token every hour, this
     // makes sure the react state and the cookie are
     // both kept up to date
-    const cancelAuthListener = firebase.auth().onIdTokenChanged((user2) => {
-      if (user2) {
-        const userData = mapUserData(user2);
-        setUserCookie(userData);
-        setUser(userData);
-      } else {
-        removeUserCookie();
-        setUser();
-      }
-    });
+    const cancelAuthListener = firebase
+      .auth()
+      .onIdTokenChanged(async (user) => {
+        if (user) {
+          const userData = await mapUserData(user)
+          setUserCookie(userData)
+          setUser(userData)
+        } else {
+          removeUserCookie()
+          setUser()
+        }
+      })
     const userFromCookie = getUserFromCookie();
+    if (!userFromCookie) {
+      router.push('/')
+      return
+    }
     setUser(userFromCookie);
 
     return () => {


### PR DESCRIPTION
The `getIdToken` method used here https://github.com/vercel/next.js/issues/18256 is only working when `signInFlow: "popup"`.

## Original issue

https://github.com/vercel/next.js/pull/18599