### PR TITLE
disable checking coindrop name vs rootPageName

### DIFF
--- a/pages/api/createPiggybank.ts
+++ b/pages/api/createPiggybank.ts
@@ -10,12 +10,12 @@ import { maxPiggybanksPerUser, piggybankPathRegex } from '../../src/settings';
 import { piggybankImageStoragePath } from '../../utils/storage/image-paths';
 import { PublicPiggybankDataType } from '../../components/PublicPiggybankPage/PublicPiggybankDataContext';
 
-const rootPageNames = readdirSync(join(process.cwd(), 'pages'))
-  .map(readdirResult => readdirResult
-    .replace('.tsx', '')
-    .replace('.jsx', '')
-    .replace('.ts', '')
-    .replace('.js', ''));
+// const rootPageNames = readdirSync(join(process.cwd(), 'pages'))
+//   .map(readdirResult => readdirResult
+//     .replace('.tsx', '')
+//     .replace('.jsx', '')
+//     .replace('.ts', '')
+//     .replace('.js', ''));
 
 const storage = new Storage({
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
@@ -27,9 +27,9 @@ const storage = new Storage({
 
 const piggybankExistsErrorMessage = 'A piggybank with this name already exists.';
 async function isPiggybankNameNonexistant(piggybankName: string) {
-  if (rootPageNames.includes(piggybankName)) {
-    throw new Error(piggybankExistsErrorMessage);
-  }
+  // if (rootPageNames.includes(piggybankName)) {
+  //   throw new Error(piggybankExistsErrorMessage);
+  // }
   const piggybank = await db()
     .collection('piggybanks')
     .doc(piggybankName)


### PR DESCRIPTION
works in development but getting "server error" when creating Coindrop on Vercel. Oddly the CI tests pass but presumably that's because they're  running on localhost.